### PR TITLE
Fix offset of chunks

### DIFF
--- a/Destructible Terrain/Assets/Scenes/SampleScene1CollisionsAndOutline.unity
+++ b/Destructible Terrain/Assets/Scenes/SampleScene1CollisionsAndOutline.unity
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Offset>k__BackingField: {x: 0, y: 0}
-  PositionToOffset: 1
+  PositionToOffset: 0
   <ChunkCountX>k__BackingField: 1
   <ChunkCountY>k__BackingField: 1
   chunkTemplate: {fileID: 5194434684234072523, guid: d131098cbcac0e44aa81693a2bba460a,
@@ -171,7 +171,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 44864347}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 15, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Destructible Terrain/Assets/Scenes/SampleScene2Optimized.unity
+++ b/Destructible Terrain/Assets/Scenes/SampleScene2Optimized.unity
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Offset>k__BackingField: {x: 0, y: 0}
-  PositionToOffset: 1
+  PositionToOffset: 0
   <ChunkCountX>k__BackingField: 1
   <ChunkCountY>k__BackingField: 1
   chunkTemplate: {fileID: 5194434684234072523, guid: 37c73454f27eef44b862eb12bd4ee2a3,
@@ -171,7 +171,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 44864347}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 31.5, y: 31.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Destructible Terrain/Assets/Scripts/Chunk/PaintableChunk/CollidableChunk/ChunkCollider/QuadTreeChunkCollider.cs
+++ b/Destructible Terrain/Assets/Scripts/Chunk/PaintableChunk/CollidableChunk/ChunkCollider/QuadTreeChunkCollider.cs
@@ -41,7 +41,7 @@ namespace DTerrain
             foreach (Rect r in rects)
             {
                 //Newly created collider will have an offset equeal to that.
-                Vector2 rColliderOffset = new Vector2(-textureSize.x / PPU / 2f + r.x + r.size.x / 2, -textureSize.y / PPU / 2f + r.y + r.size.y / 2f);
+                Vector2 rColliderOffset = new Vector2(r.x + r.size.x / 2, r.y + r.size.y / 2f);
 
                 //Find already existing BoxCollider2D that would fit newly created BoxCollider2D.
                 BoxCollider2D boxC = colls.Find(coll => coll.offset == rColliderOffset && coll.size == r.size);

--- a/Destructible Terrain/Assets/Scripts/Chunk/PaintableChunk/PaintableChunk.cs
+++ b/Destructible Terrain/Assets/Scripts/Chunk/PaintableChunk/PaintableChunk.cs
@@ -19,7 +19,7 @@ namespace DTerrain
         public virtual void Init()
         {
             SpriteRenderer = GetComponent<SpriteRenderer>();
-            SpriteRenderer.sprite = Sprite.Create(TextureSource.Texture, new Rect(0, 0, TextureSource.Texture.width, TextureSource.Texture.height), new Vector2(0.5f, 0.5f), TextureSource.PPU,0,SpriteMeshType.FullRect);
+            SpriteRenderer.sprite = Sprite.Create(TextureSource.Texture, new Rect(0, 0, TextureSource.Texture.width, TextureSource.Texture.height), new Vector2(0.0f, 0.0f), TextureSource.PPU,0,SpriteMeshType.FullRect);
             TextureSource.SetUpToRenderer(SpriteRenderer);
 
             SpriteRenderer.sortingLayerID = SortingLayerID;

--- a/Destructible Terrain/Assets/Scripts/Layer/PaintableLayer.cs
+++ b/Destructible Terrain/Assets/Scripts/Layer/PaintableLayer.cs
@@ -83,7 +83,7 @@ namespace DTerrain
                     if(sr==null)
                         sr=c.AddComponent<SpriteRenderer>();
 
-                    c.transform.position = gameObject.transform.position + new Vector3(i * (float)chunkSizeX / PPU, j * (float)chunkSizeY / PPU, 0);
+                    c.transform.position = transform.position + new Vector3(i * (float)chunkSizeX / PPU, j * (float)chunkSizeY / PPU, 0);
                     c.transform.SetParent(transform);
 
                     Chunks.Add(c.GetComponent<T>());
@@ -102,8 +102,8 @@ namespace DTerrain
 
         public int GetChunkIDByPosition(Vector2Int position)
         {
-            int xchunk = (position.x + chunkSizeX / 2) / chunkSizeX;
-            int ychunk = (position.y + chunkSizeY / 2) / chunkSizeY;
+            int xchunk = position.x / chunkSizeX;
+            int ychunk = position.y / chunkSizeY;
             int cid = xchunk * ChunkCountY + ychunk;
             return cid;
         }
@@ -136,10 +136,10 @@ namespace DTerrain
             
             int height = r.Length;
             //We don't use a method for getting chunk id because we need some variables
-            int xchunk = (x + chunkSizeX / 2) / chunkSizeX;
-            int ychunk = (y + chunkSizeY / 2) / chunkSizeY;
-            int posInChunkX = x - xchunk * chunkSizeX + chunkSizeX / 2;
-            int posInChunkY = y - ychunk * chunkSizeY + chunkSizeY / 2;
+            int xchunk = x / chunkSizeX;
+            int ychunk = y / chunkSizeY;
+            int posInChunkX = x - xchunk * chunkSizeX;
+            int posInChunkY = y - ychunk * chunkSizeY;
             int cid = xchunk * ChunkCountY + ychunk;
 
             int k = 0;


### PR DESCRIPTION
When creating chunks, sprites are currently centered on their transform position, creating strange offsets between layers (if chunks count are different). This change align all sprites with their bottom-left point, so all layers are aligned without having to set custom position. And it also simplifies some formulas, by the way!

Maybe the `Offset` and `PositionToOffset` fields on `PaintableLayer` are not needed anymore, but I did not touch them...